### PR TITLE
Fix/proc 3330 problem with jap char

### DIFF
--- a/howto.md
+++ b/howto.md
@@ -201,7 +201,7 @@ else it does not.
 
 ## Using the iGrafx File Upload Node
 
-The iGrafx Mining File Upload Node is the node that will allow you to upload you file by simply entering a file structure encoding, a [column mapping](https://github.com/igrafx/mining-python-sdk/blob/dev/howto.md#sending-data), a Project ID and a chunk size value.
+The iGrafx Mining File Upload Node is the node that will allow you to upload you file by simply entering a [column mapping](https://github.com/igrafx/mining-python-sdk/blob/dev/howto.md#sending-data), a Project ID and a chunk size value.
 A column mapping is a list of columns describing a document(.CSV, .XLSX, .XLS).
 
 

--- a/howto.md
+++ b/howto.md
@@ -201,11 +201,14 @@ else it does not.
 
 ## Using the iGrafx File Upload Node
 
-The iGrafx Mining File Upload Node is the node that will allow you to upload you file by simply entering a [column mapping](https://github.com/igrafx/mining-python-sdk/blob/dev/howto.md#sending-data), a Project ID and a chunk size value.
+The iGrafx Mining File Upload Node is the node that will allow you to upload you file by simply entering a file structure encoding, a [column mapping](https://github.com/igrafx/mining-python-sdk/blob/dev/howto.md#sending-data), a Project ID and a chunk size value.
 A column mapping is a list of columns describing a document(.CSV, .XLSX, .XLS).
 
 
-To use it, double click on it and enter the  column mapping of the file you wish to upload.
+To use the node, double click on it and enter the encoding that you wish to use for the file. 
+Note that by default, it is set to ``UTF-8`` but you can modify it as you like.  
+
+Then, enter the column mapping of the file you wish to upload.
 This has to be done in a JSON format. 
 In this JSON, for each column, there is a column number (for instance *"col1"*).
 It is then followed by the column's name, its index number and the column type.
@@ -225,7 +228,7 @@ You can also add `DIMENSION` and `METRIC` columns. For instance:
 {       "col1": "name": "end_date", "columnIndex": "3", "columnType": "TIME", "format": "yyyy-MM-dd HH:mm:ss.SSSSSS"}         }
 ````
 
-More information about Columns and column mappings can be found [here](https://github.com/igrafx/mining-python-sdk/blob/dev/howto.md#sending-data).
+More information about File Structures, Columns and column mappings can be found [here](https://github.com/igrafx/mining-python-sdk/blob/dev/howto.md#sending-data).
 
 You must also input your **Project ID**. It can be found in the URL, when you are in the project. Or you can get it with the Project Creator node output.
 

--- a/howto.md
+++ b/howto.md
@@ -205,10 +205,9 @@ The iGrafx Mining File Upload Node is the node that will allow you to upload you
 A column mapping is a list of columns describing a document(.CSV, .XLSX, .XLS).
 
 
-To use the node, double click on it and enter the encoding that you wish to use for the file. 
-Note that by default, it is set to ``UTF-8`` but you can modify it as you like.  
+**Please make sure that you are using ``UTF-8`` for the data you are planning to send, else it will result in an error.**
 
-Then, enter the column mapping of the file you wish to upload.
+To use the node, double click on it and , enter the column mapping of the file you wish to upload.
 This has to be done in a JSON format. 
 In this JSON, for each column, there is a column number (for instance *"col1"*).
 It is then followed by the column's name, its index number and the column type.
@@ -244,7 +243,7 @@ This node takes a table as input and outputs a table.
 Here are the **flow variables** of this node:
 
 | Flow variable         |               Meaning                                          |             Description  |
-|:----------------------|:--------------------------------------------------------------:|-------------------------:|
+|:----------------------|:--------------    ------------------------------------------------:|-------------------------:|
 | auth_url              |         The authentication URL of the iGrafx platform.         |       Authentication URL |
 | api_url               |       The URL of the iGrafx API platform you are using.        |                  API URL | 
 | wg_key                |     The Private Key of the workgroup you are working with.     |            Workgroup Key |

--- a/igrafx_extension/igrafx_knime_extension/igrafx_knime_extension.py
+++ b/igrafx_extension/igrafx_knime_extension/igrafx_knime_extension.py
@@ -234,7 +234,7 @@ class iGrafxFileUploadNode:
         
         my_project = wg.project_from_id(project_id)
 
-        file_structure = igx.FileStructure(file_type=igx.FileType.csv)
+        file_structure = igx.FileStructure(charset="UTF-8", file_type=igx.FileType.csv)
 
         column_mapping = igx.ColumnMapping.from_json(column_dict)
 
@@ -252,9 +252,8 @@ class iGrafxFileUploadNode:
             # Create a temporary file and write the CSV data to it
             temp_csv_file = tempfile.NamedTemporaryFile(suffix=".csv", delete=False)
             temp_csv_file_path = temp_csv_file.name
-
             # Write the CSV data to the temporary file
-            with open(temp_csv_file_path, 'w') as csv_file:
+            with open(temp_csv_file_path, 'w', encoding=file_structure.charset) as csv_file:
                 csv_file.write(csv_data)
 
             # Add the file

--- a/igrafx_extension/igrafx_knime_extension/igrafx_knime_extension.py
+++ b/igrafx_extension/igrafx_knime_extension/igrafx_knime_extension.py
@@ -190,16 +190,11 @@ class iGrafxFileUploadNode:
 
     - Column Mapping Support: Accommodates the transmission of column mapping details in JSON format, facilitating structured and organized data transfer.
 
-    - File Structure encoding Support: Allows users to specify the encoding of the file structure, ensuring that the uploaded files are properly encoded.
-    
     - Workgroup Object Connectivity: Establishes a secure connection to the iGrafx Mining API by utilizing the Workgroup Object, ensuring authentication and access permissions.
 
     This node empowers users to seamlessly integrate file upload functionalities into their KNIME workflows, enabling efficient data transfer and synchronization with the iGrafx Mining platform. By leveraging this node, users can ensure the accurate and secure uploading of files while maintaining structured data organization within the iGrafx ecosystem.
     """
-    # Define parameters for file upload
-    filestructure_encoding = knext.StringParameter("File Structure Encoding",
-                                                   "The encoding of the file structure. By default, UTF-8 is used.",
-                                                   "UTF-8")
+
     column_dict = knext.StringParameter("Column Mapping",
                                         "The column mapping of the file you want to upload in JSON format.")
     given_project_id = knext.StringParameter("Project ID",
@@ -216,7 +211,6 @@ class iGrafxFileUploadNode:
     def execute(self, exec_context, input_data):
 
         column_dict = self.column_dict
-        file_structure_encoding = self.filestructure_encoding
 
         # Get Workgroup object from the previous node
         wg = igx.Workgroup(
@@ -244,7 +238,7 @@ class iGrafxFileUploadNode:
         
         my_project = wg.project_from_id(project_id)
 
-        file_structure = igx.FileStructure(charset=file_structure_encoding, file_type=igx.FileType.csv)
+        file_structure = igx.FileStructure(charset="UTF-8", file_type=igx.FileType.csv)
 
         column_mapping = igx.ColumnMapping.from_json(column_dict)
 


### PR DESCRIPTION
A problem where in knime, encoding was incorrect.

Solved as follows:
- Set a parameter called 'file structure encoding', where the user can set his desired encoding. It is by default set to UTF-8.
- This parameter is then used when reading the file in knime so to read the file in the given encoding.
- Modified documentation accordingly.